### PR TITLE
feat: poll for notifications instead of using transactionFeed

### DIFF
--- a/src/escrow.js
+++ b/src/escrow.js
@@ -112,7 +112,7 @@ async function verify ({
   }
   const controlProgram = compiled.program
   debug('recompiled contract', controlProgram)
-  assert(utxo.controlProgram === controlProgram, 'escrow contract is not an interledger transfer or has the wrong parameters: ' + controlProgram)
+  assert(utxo.controlProgram === controlProgram, 'escrow contract is not an interledger transfer or has the wrong parameters. actual: ' + utxo.controlProgram + ' expected: ' + controlProgram)
   assert(moment().isBefore(expiresAt), 'escrow has already expired')
   debug('verified that control program matches what we expect')
   // TODO do we need to check the expiry of the control program?


### PR DESCRIPTION
the transaction feed seemed to stop working after a while so this switches the notifications to just use a local setInterval and a time bound query